### PR TITLE
Force float dtype for Tokenformer adapter parameters

### DIFF
--- a/vllm/tokenformer/tokenformer_surgeon.py
+++ b/vllm/tokenformer/tokenformer_surgeon.py
@@ -20,7 +20,13 @@ class TokenformerAdapter(nn.Module):
         self.num_heads = int(os.getenv("TOKENFORMER_NUM_HEADS", "4"))
         self.head_dim = hidden_size // self.num_heads
         self.tokenformer_r = int(os.getenv("TOKENFORMER_R", "32"))
-        self.dtype = next(layer.parameters()).dtype
+        # Use a floating-point dtype so parameters can carry gradients. Under
+        # quantized loading (e.g. NVFP4) the base layer's weight dtype is an
+        # integer packed type, which would make `nn.Parameter(requires_grad=True)`
+        # fail with "Only Tensors of floating point and complex dtype can
+        # require gradients". Fall back to float32 if the layer dtype is usable.
+        layer_dtype = next(layer.parameters()).dtype
+        self.dtype = layer_dtype if layer_dtype.is_floating_point else torch.bfloat16
 
         self.tokenformer_k = nn.Parameter(
             torch.zeros(


### PR DESCRIPTION
## Summary
- Force Tokenformer adapter parameters to a floating-point dtype so they can carry gradients when the base layer is NVFP4-quantized.
- Fixes a hard crash on model init for `nvidia/Qwen3-32B-NVFP4` (and other NVFP4 checkpoints) on DGX Spark.

## Problem
Loading `nvidia/Qwen3-32B-NVFP4` crashes during `TokenformerSurgeon.insert_adapter_modules()`:

```
RuntimeError: Only Tensors of floating point and complex dtype can require gradients
```

In `TokenformerAdapter.__init__`:

```python
self.dtype = next(layer.parameters()).dtype
...
nn.Parameter(torch.zeros(..., dtype=self.dtype))
```

picks up the base layer's packed weight dtype (uint8 for NVFP4). The `nn.Parameter` construction then fails because only floating-point and complex tensors can require gradients.

## Fix
Check `layer_dtype.is_floating_point` and fall back to `torch.bfloat16` when the base dtype is not a floating-point type. The runtime cast to activation dtype inside `tokenformer_op` is unchanged, so forward-pass precision is unaffected.

## Supersedes #20
The original PR #20 was opened from a long-lived branch that was 2111 commits behind `main`; it accumulated 27 commits / 1037 additions / 27 changed files of unrelated drift and ended up in a conflict state. This PR is the same one-line fix rebased onto current `main` — single commit, single file, 7 insertions / 1 deletion.

## Companion PR
The `ml/tokenformer/tokenformer_surgeon.py` copy in the scalarlm repo carries the same bug and is fixed in a parallel PR on branch `fix/tokenformer-nvfp4-dtype` in supermassive-intelligence/scalarlm.

## Test plan
- [ ] Build scalarlm Docker image with this fork and cold-start on DGX Spark with `model: nvidia/Qwen3-32B-NVFP4`
- [ ] Verify Tokenformer init no longer crashes
- [ ] Send a chat completion request end-to-end and confirm a valid response

🤖 Generated with [Claude Code](https://claude.com/claude-code)