### PR TITLE
Fix DeviceIndex overflow in multi-GPU tensor parallelism

### DIFF
--- a/vllm/model_executor/layers/fla/ops/solve_tril.py
+++ b/vllm/model_executor/layers/fla/ops/solve_tril.py
@@ -34,7 +34,11 @@ try:
             def get(self):
                 """Return the actual allocation function."""
                 def torch_alloc_fn(size, alignment, stream):
-                    return torch.cuda.caching_allocator_alloc(size, stream)
+                    # Fix for multi-GPU tensor parallelism: ensure we're on the correct device
+                    # to avoid "Overflow when unpacking DeviceIndex" error
+                    device = torch.cuda.current_device()
+                    with torch.cuda.device(device):
+                        return torch.cuda.caching_allocator_alloc(size, device)
                 return torch_alloc_fn
         
         # Set the global allocator


### PR DESCRIPTION
Summary
Fix "Overflow when unpacking DeviceIndex" error when running with tensor parallelism (4+ GPUs).

Problem
The TorchAllocator in solve_tril.py passed the Triton stream directly to torch.cuda.caching_allocator_alloc(). When running with tensor parallelism across multiple GPUs, the stream handle encodes a device ID that doesn't match the current device context, causing:

RuntimeError: Overflow when unpacking DeviceIndex

This crashes vLLM during Triton kernel autotuning in the FLA ops.

Solution
Use torch.cuda.current_device() to get the correct device
Pass device instead of stream to avoid cross-GPU stream handle issues
Test plan
 Run vLLM with 4-GPU tensor parallelism on Qwen3-Next-80B model
 Verify no DeviceIndex overflow during Triton autotuning