### PR TITLE
lora/fla: fix TorchAllocator .set() crash on MoE + LoRA engine init

### DIFF
--- a/vllm/model_executor/layers/fla/ops/solve_tril.py
+++ b/vllm/model_executor/layers/fla/ops/solve_tril.py
@@ -29,15 +29,37 @@ try:
         print(f"[SOLVE_TRIL] Triton version: {triton_actual.__version__}", file=sys.stderr, flush=True)
         print(f"[SOLVE_TRIL] Current allocator: {_allocation._allocator}", file=sys.stderr, flush=True)
         
-        # Create proper allocator class for Triton 3.x
+        # Allocator wrapper compatible with Triton 3.x's _allocator
+        # ContextVar-like interface. We replace `_allocation._allocator`
+        # directly rather than going through `triton.set_allocator` so
+        # the allocator sticks for the whole process (set_allocator
+        # writes to a ContextVar and can be lost across contexts).
+        #
+        # The wrapper must expose .get() / .set() / __call__ because:
+        #   - Triton's nvidia/amd drivers call `allocator.get()` at
+        #     kernel-launch time to obtain the alloc function.
+        #   - `triton.set_allocator(fn)` (called from
+        #     triton.language.core during kernel init) does
+        #     `_allocator.set(fn)` — so .set() has to exist or we crash
+        #     with "TorchAllocator object has no attribute 'set'".
+        #   - Some launch paths may treat the object itself as the alloc
+        #     callable, so __call__ delegates to the current fn.
         class TorchAllocator:
-            def get(self):
-                """Return the actual allocation function."""
+            def __init__(self) -> None:
                 def torch_alloc_fn(size, alignment, stream):
                     return torch.cuda.caching_allocator_alloc(size, stream)
-                return torch_alloc_fn
-        
-        # Set the global allocator
+                self._alloc_fn = torch_alloc_fn
+
+            def get(self):
+                return self._alloc_fn
+
+            def set(self, new_alloc) -> None:
+                self._alloc_fn = new_alloc
+
+            def __call__(self, size, alignment, stream):
+                return self._alloc_fn(size, alignment, stream)
+
+        # Install as the global allocator.
         _allocation._allocator = TorchAllocator()
         
         print(f"[SOLVE_TRIL] Set allocator to: {_allocation._allocator}", file=sys.stderr, flush=True)


### PR DESCRIPTION
The fork's solve_tril.py installs a persistent Triton allocator by overwriting `triton.runtime._allocation._allocator`. Triton 3.x declares `_allocator` as a ContextVar and internally does `_allocator.set(fn)` whenever `triton.set_allocator(...)` is called (and `.get()` whenever a kernel-launch path needs the alloc fn).

Our TorchAllocator previously only defined .get(). When vLLM engine init called triton.set_allocator from the kernel-init path, it hit `_allocator.set(fn)` and crashed:

    AttributeError: 'TorchAllocator' object has no attribute 'set'.
    Did you mean: 'get'?

The crash only fires on MoE models with --enable-lora because that's where the FLA path meets a LoRA layer that touches Triton's allocator set(). Dense models and non-LoRA paths never enter the set() branch.

History / note for reviewers: this is fork-only code (upstream's solve_tril.py has no allocator override; see commit 9fce7bee7). The same regression was fixed once before in 008199e82 "patch vllm allocator for amd", but the fix was clobbered when the fork was re-squashed onto v0.19.0 in 27d57e2e3 a month later.

Fix: give TorchAllocator the full ContextVar-like surface — `.get()`, `.set()`, and `__call__` — matching Triton's own _AllocatorWrapper class. This keeps the original "replace with a process-wide object" intent of the fork (surviving subprocess forks in a way ContextVar .set() does not), while exposing every interface Triton reaches for.

Repro: any MoE model with `--enable-lora --pipeline-parallel-size=2` on vLLM built from this fork — e.g. Qwen/Qwen3-Next-80B-A3B-Instruct- FP8. Crashes at engine core init in ~30s; engine init succeeds after.
