### PR TITLE
lora/fla: scratch-allocator memleak fix + libtorch_stable torch 2.10 ABI fix

### DIFF
--- a/csrc/libtorch_stable/ops.h
+++ b/csrc/libtorch_stable/ops.h
@@ -7,9 +7,13 @@
 torch::stable::Tensor permute_cols(torch::stable::Tensor const& A,
                                    torch::stable::Tensor const& perm);
 
+// Note: output tensors are passed by value (not `Tensor&`) because the
+// PyTorch 2.10 stable ABI's `torch::stable::detail::to<T>` requires `T` to be
+// trivially copyable, which excludes references. Schema-level mutability is
+// still conveyed via the `Tensor!` marker in the op definition string.
 void per_token_group_quant_fp8(const torch::stable::Tensor& input,
-                               torch::stable::Tensor& output_q,
-                               torch::stable::Tensor& output_s,
+                               torch::stable::Tensor output_q,
+                               torch::stable::Tensor output_s,
                                int64_t group_size, double eps, double fp8_min,
                                double fp8_max, bool scale_ue8m0,
                                bool dummy_is_scale_transposed,
@@ -17,14 +21,14 @@ void per_token_group_quant_fp8(const torch::stable::Tensor& input,
 
 // Fused activation quantisation + DeepGEMM-compatible UE8M0-packed scales.
 void per_token_group_quant_8bit_packed(const torch::stable::Tensor& input,
-                                       torch::stable::Tensor& output_q,
-                                       torch::stable::Tensor& output_s_packed,
+                                       torch::stable::Tensor output_q,
+                                       torch::stable::Tensor output_s_packed,
                                        int64_t group_size, double eps,
                                        double min_8bit, double max_8bit);
 
 void per_token_group_quant_int8(const torch::stable::Tensor& input,
-                                torch::stable::Tensor& output_q,
-                                torch::stable::Tensor& output_s,
+                                torch::stable::Tensor output_q,
+                                torch::stable::Tensor output_s,
                                 int64_t group_size, double eps, double int8_min,
                                 double int8_max);
 #endif

--- a/csrc/libtorch_stable/ops.h
+++ b/csrc/libtorch_stable/ops.h
@@ -4,14 +4,15 @@
 #include <torch/csrc/stable/tensor.h>
 
 #ifndef USE_ROCM
-torch::stable::Tensor permute_cols(torch::stable::Tensor const& A,
-                                   torch::stable::Tensor const& perm);
-
-// Note: output tensors are passed by value (not `Tensor&`) because the
+// Note: tensor params are passed by value (not by reference) because the
 // PyTorch 2.10 stable ABI's `torch::stable::detail::to<T>` requires `T` to be
-// trivially copyable, which excludes references. Schema-level mutability is
-// still conveyed via the `Tensor!` marker in the op definition string.
-void per_token_group_quant_fp8(const torch::stable::Tensor& input,
+// trivially copyable, which excludes both `Tensor&` and `const Tensor&`.
+// Schema-level mutability is still conveyed via the `Tensor!` marker in the
+// op definition string.
+torch::stable::Tensor permute_cols(torch::stable::Tensor A,
+                                   torch::stable::Tensor perm);
+
+void per_token_group_quant_fp8(torch::stable::Tensor input,
                                torch::stable::Tensor output_q,
                                torch::stable::Tensor output_s,
                                int64_t group_size, double eps, double fp8_min,
@@ -20,13 +21,13 @@ void per_token_group_quant_fp8(const torch::stable::Tensor& input,
                                bool dummy_is_tma_aligned);
 
 // Fused activation quantisation + DeepGEMM-compatible UE8M0-packed scales.
-void per_token_group_quant_8bit_packed(const torch::stable::Tensor& input,
+void per_token_group_quant_8bit_packed(torch::stable::Tensor input,
                                        torch::stable::Tensor output_q,
                                        torch::stable::Tensor output_s_packed,
                                        int64_t group_size, double eps,
                                        double min_8bit, double max_8bit);
 
-void per_token_group_quant_int8(const torch::stable::Tensor& input,
+void per_token_group_quant_int8(torch::stable::Tensor input,
                                 torch::stable::Tensor output_q,
                                 torch::stable::Tensor output_s,
                                 int64_t group_size, double eps, double int8_min,

--- a/csrc/libtorch_stable/permute_cols.cu
+++ b/csrc/libtorch_stable/permute_cols.cu
@@ -67,8 +67,8 @@ __global__ void permute_cols_kernel(int4 const* __restrict__ a_int4_ptr,
 
 // More efficient version of A[..., perm]
 //  taken from gptq_marlin.cu
-torch::stable::Tensor permute_cols(torch::stable::Tensor const& A,
-                                   torch::stable::Tensor const& perm) {
+torch::stable::Tensor permute_cols(torch::stable::Tensor A,
+                                   torch::stable::Tensor perm) {
   const int32_t dev = A.get_device_index();
   const torch::stable::accelerator::DeviceGuard device_guard(dev);
   const auto stream = get_current_cuda_stream(dev);

--- a/csrc/libtorch_stable/quantization/w8a8/fp8/per_token_group_quant.cu
+++ b/csrc/libtorch_stable/quantization/w8a8/fp8/per_token_group_quant.cu
@@ -297,8 +297,8 @@ __global__ void per_token_group_quant_8bit_packed_kernel(
 }
 
 void per_token_group_quant_8bit_packed(const torch::stable::Tensor& input,
-                                       torch::stable::Tensor& output_q,
-                                       torch::stable::Tensor& output_s_packed,
+                                       torch::stable::Tensor output_q,
+                                       torch::stable::Tensor output_s_packed,
                                        int64_t group_size, double eps,
                                        double min_8bit, double max_8bit) {
   STD_TORCH_CHECK(input.is_contiguous());
@@ -380,8 +380,8 @@ void per_token_group_quant_8bit_packed(const torch::stable::Tensor& input,
 }
 
 void per_token_group_quant_fp8(const torch::stable::Tensor& input,
-                               torch::stable::Tensor& output_q,
-                               torch::stable::Tensor& output_s,
+                               torch::stable::Tensor output_q,
+                               torch::stable::Tensor output_s,
                                int64_t group_size, double eps, double fp8_min,
                                double fp8_max, bool scale_ue8m0,
                                bool dummy_is_scale_transposed = false,

--- a/csrc/libtorch_stable/quantization/w8a8/fp8/per_token_group_quant.cu
+++ b/csrc/libtorch_stable/quantization/w8a8/fp8/per_token_group_quant.cu
@@ -296,7 +296,7 @@ __global__ void per_token_group_quant_8bit_packed_kernel(
                               threads_per_group, y_s, min_8bit, max_8bit);
 }
 
-void per_token_group_quant_8bit_packed(const torch::stable::Tensor& input,
+void per_token_group_quant_8bit_packed(torch::stable::Tensor input,
                                        torch::stable::Tensor output_q,
                                        torch::stable::Tensor output_s_packed,
                                        int64_t group_size, double eps,
@@ -379,7 +379,7 @@ void per_token_group_quant_8bit_packed(const torch::stable::Tensor& input,
 #undef LAUNCH_PACKED_KERNEL
 }
 
-void per_token_group_quant_fp8(const torch::stable::Tensor& input,
+void per_token_group_quant_fp8(torch::stable::Tensor input,
                                torch::stable::Tensor output_q,
                                torch::stable::Tensor output_s,
                                int64_t group_size, double eps, double fp8_min,

--- a/csrc/libtorch_stable/quantization/w8a8/int8/per_token_group_quant.cu
+++ b/csrc/libtorch_stable/quantization/w8a8/int8/per_token_group_quant.cu
@@ -3,8 +3,8 @@
 #include "libtorch_stable/quantization/w8a8/per_token_group_quant_8bit.h"
 
 void per_token_group_quant_int8(const torch::stable::Tensor& input,
-                                torch::stable::Tensor& output_q,
-                                torch::stable::Tensor& output_s,
+                                torch::stable::Tensor output_q,
+                                torch::stable::Tensor output_s,
                                 int64_t group_size, double eps, double int8_min,
                                 double int8_max) {
   per_token_group_quant_8bit(input, output_q, output_s, group_size, eps,

--- a/csrc/libtorch_stable/quantization/w8a8/int8/per_token_group_quant.cu
+++ b/csrc/libtorch_stable/quantization/w8a8/int8/per_token_group_quant.cu
@@ -2,7 +2,7 @@
 
 #include "libtorch_stable/quantization/w8a8/per_token_group_quant_8bit.h"
 
-void per_token_group_quant_int8(const torch::stable::Tensor& input,
+void per_token_group_quant_int8(torch::stable::Tensor input,
                                 torch::stable::Tensor output_q,
                                 torch::stable::Tensor output_s,
                                 int64_t group_size, double eps, double int8_min,

--- a/vllm/model_executor/layers/fla/ops/solve_tril.py
+++ b/vllm/model_executor/layers/fla/ops/solve_tril.py
@@ -35,19 +35,38 @@ try:
         # the allocator sticks for the whole process (set_allocator
         # writes to a ContextVar and can be lost across contexts).
         #
-        # The wrapper must expose .get() / .set() / __call__ because:
-        #   - Triton's nvidia/amd drivers call `allocator.get()` at
-        #     kernel-launch time to obtain the alloc function.
-        #   - `triton.set_allocator(fn)` (called from
-        #     triton.language.core during kernel init) does
-        #     `_allocator.set(fn)` — so .set() has to exist or we crash
-        #     with "TorchAllocator object has no attribute 'set'".
-        #   - Some launch paths may treat the object itself as the alloc
-        #     callable, so __call__ delegates to the current fn.
+        # Two requirements on the wrapper, both observed in production:
+        #
+        # 1. The class must expose .get() / .set() / __call__ because:
+        #      - Triton's nvidia/amd drivers call `allocator.get()` at
+        #        kernel-launch time to obtain the alloc function.
+        #      - `triton.set_allocator(fn)` (called from
+        #        triton.language.core during kernel init) does
+        #        `_allocator.set(fn)` — so .set() has to exist or we
+        #        crash with "TorchAllocator object has no attribute
+        #        'set'". (Fixed in 376309ec.)
+        #      - Some launch paths may treat the object itself as the
+        #        alloc callable, so __call__ delegates to the current
+        #        fn.
+        #
+        # 2. `torch_alloc_fn` returns a `torch.Tensor` rather than a raw
+        #    device pointer. `torch.cuda.caching_allocator_alloc` hands
+        #    back an int pointer that is only reclaimed when the caller
+        #    explicitly calls `caching_allocator_delete(ptr)`, which
+        #    Triton never does — so each kernel-launch scratch
+        #    allocation would leak forever. Returning a `torch.Tensor`
+        #    satisfies Triton's Buffer protocol (it exposes
+        #    `data_ptr()`) and lets the caching allocator reclaim the
+        #    block automatically as soon as Triton drops its reference
+        #    after the kernel completes.
         class TorchAllocator:
             def __init__(self) -> None:
                 def torch_alloc_fn(size, alignment, stream):
-                    return torch.cuda.caching_allocator_alloc(size, stream)
+                    return torch.empty(
+                        size,
+                        dtype=torch.int8,
+                        device=torch.cuda.current_device(),
+                    )
                 self._alloc_fn = torch_alloc_fn
 
             def get(self):


### PR DESCRIPTION
## Summary

Three commits, all bringing `scalarlm-on-v0.19.0` to a clean state for current torch 2.10 + production scalarlm builds. The first is the original memleak fix (this branch's purpose); the other two are cherry-picks of Greg's earlier ABI fixes from `main` that never propagated to `scalarlm-on-v0.19.0`.

| # | Commit | What it does |
|---|---|---|
| 1 | `867904daf` | **Memleak fix** — `TorchAllocator.torch_alloc_fn` returns `torch.Tensor` (auto-reclaimed) instead of raw `caching_allocator_alloc` pointer (leaked forever). Fixes long-MoE-run CUDA OOMs. Same diff as the original PR #25 scope. |
| 2 | `c9ef1287b` | **`libtorch_stable: pass output tensors by value for torch 2.10 ABI`** — cherry-pick of `5a670ff7a` from `main`. |
| 3 | `01f4bae62` | **`libtorch_stable: pass all tensor params by value for torch 2.10 ABI`** — cherry-pick of `4fd1236e9` from `main`. |

## Why the cherry-picks

vllm-fork's `csrc/libtorch_stable/{ops.h,permute_cols.cu,quantization/w8a8/{fp8,int8}/per_token_group_quant.cu}` use the `torch::stable` ABI. Torch 2.10 hardened that ABI — reference parameters (`const torch::stable::Tensor&`) are no longer unboxable through the templated `Result::t` union (a reference can't be a non-static data member of a union, and `is_trivially_copyable_v<T&>` is false).

Greg fixed this on `main` (`5a670ff7a` and `4fd1236e9`) on **2026-04-18**, two days **after** `scalarlm-on-v0.19.0` was cut on **2026-04-16** (`27d57e2e3`). The fixes never propagated to the active scalarlm branch.

Result: a fresh `docker build --build-arg VLLM_BRANCH=scalarlm-on-v0.19.0` against current torch fails with:

```
error: non-static data member 'torch::stable::detail::ToImpl<torch::stable::Tensor&>::call(...)::Result::t'
       in a union may not have reference type 'torch::stable::Tensor&'
```

at `vllm/csrc/libtorch_stable/torch_bindings.cpp:44`. With the cherry-picks, that file's referenced functions (`per_token_group_quant_fp8`, etc.) are registered with value parameters and the build compiles.

## Why bundled with the memleak fix

Both classes of change share the same end goal — making `scalarlm-on-v0.19.0` a usable target for production scalarlm builds. The memleak fix is a runtime bug (CUDA OOMs on long MoE runs); the ABI fix is a build-time bug (fresh builds don't compile). Splitting them buys nothing — they're both Greg's work originally, both small, and both straightforward.

## Test plan

- [ ] Fresh scalarlm Docker build against `scalarlm-on-v0.19.0` pinned to this branch's HEAD (`01f4bae62`) compiles to a working image. (Currently in progress — will report back.)
- [ ] MoE+LoRA engine init succeeds (regression check from PR #24's crash fix).
- [ ] Long MoE inference run on Blackwell — allocator pool stays bounded across thousands of kernel launches (memleak fix).

## Out of scope

- Same ABI issue exists on `main`'s parallel `TorchAllocator` use sites — already fixed there directly by Greg (`5a670ff7a`, `4fd1236e9`).
- Same memleak exists on `main` (different `TorchAllocator` shape). Will get picked up at the next `scalarlm-on-vX.Y.Z` re-cut, or a separate fork PR if needed sooner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)