### PR TITLE
Gemma4: support quantized MoE (cherry-pick of upstream #39045)

### DIFF
--- a/vllm/model_executor/models/gemma4.py
+++ b/vllm/model_executor/models/gemma4.py
@@ -926,21 +926,27 @@ class Gemma4Model(nn.Module):
             ("gate_up_proj", "up_proj", 1),
         ]
 
-        # MoE expert weight mapping: checkpoint 3D packed tensors are
-        # exploded in _weight_iterator to per-expert 2D weights like:
+        # MoE expert weight mapping: checkpoint can have either:
+        #   1. 3D packed tensors (exploded in _weight_iterator to per-expert 2D)
+        #   2. Already per-expert 2D weights (if quantized)
+        # Map to FusedMoE parameters:
         #   moe.experts.{id}.gate_proj → FusedMoE w1 (shard of w13)
         #   moe.experts.{id}.up_proj   → FusedMoE w3 (shard of w13)
         #   moe.experts.{id}.down_proj → FusedMoE w2
-        # We build the mapping directly since Gemma4 uses bare param
-        # names (no .weight suffix) unlike standard MoE checkpoints.
+        #
+        # Use prefix matching to handle both weights and
+        # quantization scale parameters. The param_name is a prefix ending
+        # in underscore, and weight_name ends with a dot, so that:
+        #   "experts.0.gate_proj.weight_scale" -> "experts.w13_weight_scale"
+        #   "experts.0.gate_proj.weight" -> "experts.w13_weight"
         num_experts = getattr(self.config, "num_experts", None) or 0
         expert_params_mapping = [
             # (param_name, weight_name, expert_id, shard_id)
             (
-                "experts.w13_weight"
+                "experts.w13_"
                 if proj_name in ["gate_proj", "up_proj"]
-                else "experts.w2_weight",
-                f"experts.{expert_id}.{proj_name}",
+                else "experts.w2_",
+                f"experts.{expert_id}.{proj_name}.",
                 expert_id,
                 shard_id,
             )
@@ -1000,9 +1006,21 @@ class Gemma4Model(nn.Module):
                     expert_id,
                     shard_id,
                 ) in expert_params_mapping:
-                    if weight_name not in name:
+                    # Match both:
+                    #  - Bare weights: "experts.0.down_proj" (from 3D explosion)
+                    #  - With suffix: "experts.0.down_proj.weight_scale" (2D quantized)
+                    # weight_name has trailing dot, so check with and without it
+                    weight_name_base = weight_name.rstrip(".")
+                    if weight_name in name:
+                        # Has suffix (e.g., .weight_scale)
+                        moe_name = name.replace(weight_name, param_name)
+                    elif name.endswith(weight_name_base):
+                        # Bare weight (no suffix)
+                        moe_name = name.replace(
+                            weight_name_base, param_name.rstrip("_") + "_weight"
+                        )
+                    else:
                         continue
-                    moe_name = name.replace(weight_name, param_name)
                     if moe_name not in params_dict:
                         continue
                     if is_pp_missing_parameter(moe_name, self):
@@ -1012,15 +1030,12 @@ class Gemma4Model(nn.Module):
                     # orientation for FusedMoE after _weight_iterator:
                     #   gate/up: [I, H] → w1/w3 expects [I, H]
                     #   down:    [H, I] → w2 expects [H, I]
-                    assert loaded_weight.dim() == 2, (
-                        f"Expected 2D expert weight for {weight_name}, "
-                        f"got shape {loaded_weight.shape}"
-                    )
+                    # Scales and other quantization params may be 1D or scalar.
                     weight_loader = param.weight_loader
                     weight_loader(
                         param,
                         loaded_weight,
-                        weight_name + ".weight",
+                        moe_name,  # Pass mapped name (handles both weights and scales)
                         shard_id=shard_id,
                         expert_id=expert_id,
                     )
@@ -1176,6 +1191,11 @@ class Gemma4ForCausalLM(nn.Module, SupportsLoRA, SupportsPP, MixtureOfExperts):
                         ".experts.down_proj",
                         ".moe.down_proj",
                     )
+
+                # Remap individual 2D expert weights:
+                # .experts.{id}.{proj} → .moe.experts.{id}.{proj}
+                # (This handles per-expert 2D quantized weights)
+                name = re.sub(r"\.experts\.(\d+)\.", r".moe.experts.\1.", name)
 
                 # MoE expert weights: checkpoint stores as 3D packed
                 # tensors.  Explode into per-expert 2D weights for


### PR DESCRIPTION
## Summary

Cherry-pick of [vllm-project/vllm#39045 — `[Gemma4] Support quantized MoE`](https://github.com/vllm-project/vllm/commit/3aecdf08b) onto vllm-fork's `main`. Fixes a `KeyError` when loading any quantized Gemma 4 MoE checkpoint (NVFP4, FP8, etc.).

Concretely, this unblocks deployments of `nvidia/Gemma-4-26B-A4B-NVFP4` and similar quantized variants, which currently crash with:

```
File "vllm/model_executor/models/gemma4.py", line 1037, in load_weights
    param = params_dict[name]
KeyError: 'layers.0.experts.0.down_proj.input_scale'
```

(Replaces the earlier #26 against `scalarlm-on-v0.19.0`, which I opened on autopilot from the PR #25 pattern. After scalarlm [#176](https://github.com/supermassive-intelligence/scalarlm/pull/176), production builds target `main`, so `main` is the correct branch.)

## What was wrong

`Gemma4Model.load_weights` was hard-coded for the BF16 case:

1. `expert_params_mapping` used `_weight` suffix (`experts.w13_weight`) — fine for bare weights, can't match `experts.w13_input_scale` / `experts.w13_weight_scale`.
2. The weight_loader call passed `weight_name + ".weight"` literally, so even if the param had been found, the FusedMoE loader couldn't tell scales from weights.
3. `_weight_iterator` only normalized 3D-packed forms (`experts.gate_up_proj`, `experts.down_proj`); pre-exploded per-expert names like `experts.0.down_proj.input_scale` (which NVFP4 checkpoints contain) passed through without the `moe.` segment, so they could never match the model's actual parameter paths.
4. An `assert loaded_weight.dim() == 2` in the expert load path tripped on 1D / scalar scale tensors.

## What this PR does

Replaces all four with the upstream fix:

- Switches `expert_params_mapping` to **prefix form** (`experts.w13_` / `experts.w2_`) so the same mapping handles both bare weights and any quantization scale suffix.
- Inserts `name = re.sub(r"\.experts\.(\d+)\.", r".moe.experts.\1.", name)` in `_weight_iterator` before the 3D-explosion path, so per-expert scale tensors get the `moe.` segment in their path and align with where the model's parameters actually live.
- Passes the mapped param name to the FusedMoE `weight_loader` so it routes scales vs weights correctly.
- Drops the `dim() == 2` assertion (scales are 1D).

The infrastructure to receive these scales already exists — `modelopt.py:845-846` registers `w13_input_scale` / `w2_input_scale` as `Parameter`s on the FusedMoE layer when ModelOpt-NVFP4 quantization is the active config. The bug was purely in the name-mapping path on Gemma 4.

## Why cherry-pick instead of merging upstream's whole gemma4.py

Upstream has nine commits to `gemma4.py` since the fork's base (`8adcf8c40`). Three of them — `45232a454` (Triton routing kernel), `1c2c1eb8b` (FusedMoE refactor: rename `make_expert_params_mapping`), `726efe177` (FusedMoE refactor) — have non-trivial dependencies on FusedMoE changes that the fork doesn't have yet. Cherry-picking just `3aecdf08b` is the minimum viable fix and it applies cleanly with auto-merge, no conflicts.

The follow-up `ca97f7b9b` ("Fix Gemma4 MoE expert weight remapping") adds a negative-lookbehind to the regex (`(?<!\.moe)`) to guard against double-substitution, but it's wrapped in additions that depend on `45232a454`. In this PR's context the regex runs *before* the 3D-explosion path adds `moe.` segments, so the lookbehind isn't required — the input names never have `moe.experts.\d+.` at the point of substitution. (If someone later reorders the iterator, that protection should be re-introduced manually.)

## Test plan

- [ ] Build scalarlm image from `main` after this merges, deploy, load `nvidia/Gemma-4-26B-A4B-NVFP4`, confirm engine-init succeeds and inference returns sensible output.
- [ ] Confirm BF16 Gemma 4 MoE checkpoints still load (regression check — the prefix-form `expert_params_mapping` plus the `if weight_name in name / elif name.endswith(weight_name_base)` fork in the loader are designed to handle both, but worth verifying).
- [ ] Confirm non-MoE Gemma 4 (the dense `Gemma4ForCausalLM`) is unaffected — this PR only touches the MoE class's weight-loading paths.

## Out of scope

- The other six upstream gemma4 commits (Eagle3 support, fused routing, MoE refactors, LoRA fixes, PP fix). Each is independently useful but introduces dependencies on FusedMoE / parallel-state / LoRA changes the fork doesn't have. Best handled as a future "rebase onto a newer upstream" effort, not piecemeal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)