### PR TITLE
fix(tokenformer): keep model. prefix for causal-LM LoRA keys (supersede #29 runtime workaround)

### DIFF
--- a/tests/tokenformer/test_adapter_format.py
+++ b/tests/tokenformer/test_adapter_format.py
@@ -184,6 +184,25 @@ def test_normalize_gemma4_mlp_key_from_real_trainer_output():
     )
 
 
+def test_normalize_keeps_model_prefix_for_causal_lm_decoder():
+    """Text-only causal LMs (Gemma3ForCausalLM, Qwen2ForCausalLM, ...)
+    keep the top-level `model.` prefix in vLLM's module tree
+    (`model.layers.<N>...`). Stripping it produces `layers.<N>...`,
+    which matches no module, so the adapter loads but silently no-ops
+    at activation. Regression for that exact failure."""
+    for trainer_key, expected in [
+        (
+            "model.layers.0.self_attn.q_proj.lora_A.default.weight",
+            "model.layers.0.self_attn.q_proj.lora_A.weight",
+        ),
+        (
+            "model.layers.5.mlp.down_proj.lora_B.default.weight",
+            "model.layers.5.mlp.down_proj.lora_B.weight",
+        ),
+    ]:
+        assert normalize_lora_key(trainer_key) == expected
+
+
 def test_split_normalizes_peft_default_segment():
     """`.lora_A.default.weight` and `.lora_B.default.weight` collapse
     to vLLM's expected `.lora_A.weight` / `.lora_B.weight`, combined

--- a/vllm/tokenformer/adapter_format.py
+++ b/vllm/tokenformer/adapter_format.py
@@ -59,10 +59,10 @@ def normalize_lora_key(key: str) -> str:
         vision_tower.encoder.layers.<N>...      (no leading `model.`)
         embed_vision.embedding_projection       (no leading `model.`)
 
-    For decoder-only models (e.g. Qwen3.5), the trainer saves keys under
-    the standard HF `model.layers.<N>...` prefix, which matches vLLM's
-    module tree exactly — vLLM keeps the `model.` prefix for these models.
-    Example:
+    For text-only causal LMs (e.g. Qwen3, Qwen2ForCausalLM,
+    Gemma3ForCausalLM), the trainer saves keys under the standard HF
+    `model.layers.<N>...` prefix, which matches vLLM's module tree
+    exactly — vLLM keeps the `model.` prefix for these models. Example:
 
         model.layers.0.self_attn.q_proj.lora_A.default.weight
         → model.layers.0.self_attn.q_proj.lora_A.weight   (step 2 only)
@@ -73,12 +73,12 @@ def normalize_lora_key(key: str) -> str:
          - `model.language_model.X` → `language_model.model.X`
            (HF has `.language_model.layers`; vLLM has `.language_model.model.layers`.
            Swap them.)
-         - `model.vision_tower.X`, `model.embed_vision.X`, etc.
-           (Gemma4 multimodal sub-modules) → strip leading `model.`
-           because vLLM does not nest these under a top-level `model.`.
-         - `model.layers.X` and other decoder-only keys → leave as-is.
-           vLLM's decoder-only module trees (e.g. Qwen3.5) keep the
-           `model.` prefix, so stripping it would break key matching.
+         - `model.layers.X` → `model.layers.X` (unchanged)
+           (Text-only causal LMs keep the top-level `model.` in vLLM's
+           tree; stripping it makes the adapter silently no-op.)
+         - `model.X` (any other `model.` prefix) → `X`
+           (The multimodal wrapper's vision_tower / embed_vision / ...
+           subtrees sit at the top level in vLLM without `model.`.)
 
       2. PEFT PeftModel adapter-name segment:
          - `.lora_A.default.weight` → `.lora_A.weight`
@@ -94,9 +94,16 @@ def normalize_lora_key(key: str) -> str:
         # vLLM has `.language_model.model.layers`.
         key = "language_model.model." + key[len("model.language_model."):]
     elif key.startswith("model.layers."):
-        # Qwen3.5: trainer saves under `model.layers.*` but this vLLM
-        # build wraps the decoder under `language_model.model.layers.*`.
-        key = "language_model.model." + key[len("model."):]
+        # Text-only causal LMs (Gemma3ForCausalLM, Qwen2ForCausalLM, ...)
+        # keep the top-level `model.` prefix in vLLM's module tree — their
+        # decoder is `model.layers.<N>...`. Do NOT strip it: stripping
+        # yields `layers.<N>...`, which matches no module, so the adapter
+        # loads but silently no-ops at activation (every layer hits the
+        # "No LoRA weights found ... skipping" branch in
+        # LoRAModelManager.activate_adapter). Only the multimodal wrapper's
+        # sibling subtrees (vision_tower, embed_vision, ...) live at the top
+        # level without `model.` and need the prefix removed below.
+        pass
     elif key.startswith("model."):
         # Gemma4 multimodal sub-modules (vision_tower, embed_vision, …):
         # vLLM exposes these without the top-level `model.` wrapper.

--- a/vllm/tokenformer/hybrid_adapter_manager.py
+++ b/vllm/tokenformer/hybrid_adapter_manager.py
@@ -28,7 +28,6 @@ from vllm.lora.worker_manager import LRUCacheWorkerLoRAManager
 from vllm.tokenformer.adapter_format import (
     AdapterKind,
     load_adapter_from_pt,
-    normalize_lora_state_dict,
 )
 from vllm.tokenformer.lora_from_pt import load_lora_model_from_pt
 from vllm.tokenformer.tokenformer_model_manager import TokenformerModelManager
@@ -78,13 +77,8 @@ class PTWorkerLoRAManager(LRUCacheWorkerLoRAManager):
                 f"--enable-tokenformer instead, or as a hybrid adapter "
                 f"with both --enable-lora and --enable-tokenformer."
             )
-        # Re-normalize the lora_sd using the live model's prefix so the
-        # same .pt file works across model families (e.g. Qwen3-4B uses
-        # `model.layers.*` while Qwen3.5-4B uses
-        # `language_model.model.layers.*`).
-        lora_sd = self._renormalize_lora_sd_for_model(loaded.lora_sd)
         lora_model = load_lora_model_from_pt(
-            lora_sd,
+            loaded.lora_sd,
             lora_model_id=lora_request.adapter_id,
             device=self.device,
             dtype=(
@@ -102,103 +96,6 @@ class PTWorkerLoRAManager(LRUCacheWorkerLoRAManager):
         )
         self._warn_on_zero_base_match(lora_model, loaded.source_path)
         return lora_model
-
-    def _detect_model_layers_prefix(self) -> str:
-        """Probe the live base model to find which prefix its decoder
-        layers use.  Returns the string that should replace the
-        training-side ``model.layers.`` prefix in LoRA keys.
-
-        Known variants:
-          - ``model.layers.``            — standard decoder-only (Qwen3)
-          - ``language_model.model.layers.`` — VL-wrapped decoder
-                                               (Qwen3.5, Gemma4)
-
-        Falls back to ``model.layers.`` (the vLLM default) if the
-        model tree is not accessible.
-        """
-        try:
-            model = self._adapter_manager.model
-            for name, _ in model.named_modules():
-                if name.endswith(".self_attn") or name.endswith(".mlp"):
-                    # Strip the layer suffix to get the layers container
-                    # e.g. "language_model.model.layers.0.self_attn"
-                    #   -> "language_model.model.layers."
-                    # or  "model.layers.0.self_attn"
-                    #   -> "model.layers."
-                    parts = name.split(".")
-                    try:
-                        layers_idx = next(
-                            i for i, p in enumerate(parts) if p == "layers"
-                        )
-                        prefix = ".".join(parts[: layers_idx + 1]) + "."
-                        logger.debug(
-                            "Detected model layers prefix: %s", prefix
-                        )
-                        return prefix
-                    except StopIteration:
-                        continue
-        except Exception:
-            pass
-        logger.debug(
-            "Could not detect model layers prefix; defaulting to "
-            "model.layers."
-        )
-        return "model.layers."
-
-    def _renormalize_lora_sd_for_model(
-        self, lora_sd: dict
-    ) -> dict:
-        """Re-run key normalization using the live model's prefix.
-
-        ``adapter_format.normalize_lora_key`` uses a static rule that
-        maps ``model.layers.*`` to ``language_model.model.layers.*``
-        (needed for Qwen3.5/Gemma4).  For models whose vLLM tree really
-        does use ``model.layers.*`` (e.g. Qwen3-4B-Instruct) that
-        mapping is wrong.
-
-        This method detects the correct target prefix from the live
-        model, then re-applies *only* the structural part of the
-        normalization (prefix swap + PEFT ``.default.`` strip +
-        ClippableLinear ``.linear.`` strip) with the right target.
-        """
-        target_prefix = self._detect_model_layers_prefix()
-        # target_prefix is e.g. "model.layers." or
-        # "language_model.model.layers."
-
-        out: dict = {}
-        for k, v in lora_sd.items():
-            # The key has already been through normalize_lora_key once
-            # (inside load_adapter_from_pt -> split_adapter_state_dict).
-            # That pass may have mapped it to the wrong prefix.  We
-            # undo the structural prefix and re-apply with the correct
-            # target.
-
-            # Undo any previous prefix normalization: if the key starts
-            # with a known vLLM prefix that isn't the target, strip it
-            # back to bare "layers.*" then re-prefix.
-            KNOWN_PREFIXES = (
-                "language_model.model.layers.",
-                "model.layers.",
-            )
-            bare = k
-            for kp in KNOWN_PREFIXES:
-                if k.startswith(kp):
-                    bare = "layers." + k[len(kp):]
-                    break
-
-            # Re-prefix with the correct target
-            if bare.startswith("layers."):
-                nk = target_prefix + bare[len("layers."):]
-            else:
-                nk = k  # non-layers key (vision_tower, embed_vision, …)
-
-            if nk in out:
-                raise ValueError(
-                    f"LoRA key re-normalization collision: {k!r} and an "
-                    f"earlier key both map to {nk!r}."
-                )
-            out[nk] = v
-        return out
 
     def _warn_on_zero_base_match(self, lora_model, source_path) -> None:
         """If every parsed LoRA module path is missing from the base


### PR DESCRIPTION
## Problem
`normalize_lora_key` mapped every `model.layers.<N>...` adapter key to
`language_model.model.layers.<N>...`. That is correct only for the multimodal
Gemma4 wrapper. For text-only causal LMs (Qwen3-14B/32B/Next, Gemma3ForCausalLM,
…) whose vLLM decoder really is `model.layers.<N>...`, the rewrite produced a key
matching no module, so the adapter **loaded successfully but silently no-op'd** at
activation — every layer hit the "No LoRA weights found … skipping" branch in
`LoRAModelManager.activate_adapter` and the served output was identical to the
base model.

## Fix
1. `normalize_lora_key`: keep the `model.` prefix for `model.layers.*` decoder
   keys; only the multimodal sibling subtrees (`vision_tower`, `embed_vision`, …)
   still get the leading `model.` stripped. Adds a regression test for the
   causal-LM decoder case.
2. Removes the now-redundant runtime renormalization
   (`_detect_model_layers_prefix` / `_renormalize_lora_sd_for_model`) that PR #29
   added to repair the wrong static mapping at load time. The
   `_warn_on_zero_base_match` safety net (logs when an adapter would silently
   no-op) is retained.

Net: +40 / −117 lines across `adapter_format.py`, `hybrid_adapter_manager.py`,
and the test.

## Relationship to PR #29 (non-duplication)
PR #29 fixed the *same* Qwen3 bug by probing the live model's `named_modules()`
and re-mapping keys at load time — a runtime workaround for the wrong static rule.
This PR fixes the rule at the source, which makes that machinery dead code, so it
is removed. The approaches are mutually exclusive, not additive; this is not a
duplicate fix but a replacement that deletes the runtime path.

Evidence the static fix is correct for every trained family: the ScalarLM trainer
always loads the base model via `AutoModelForCausalLM`
(`ml/cray_megatron/models/load_model.py`), so exported key prefixes mirror the HF
module tree exactly:
- text-only causal LMs (Qwen3-14B/32B/Next) export `model.layers.*`; vLLM's tree
  is `model.layers.*` → identity mapping (correct after this PR, broken before).
- multimodal (Gemma4) exports `model.language_model.*`, handled identically by the
  first branch of `normalize_lora_key` before and after this change.

The deployed training configs are exactly these families
(`deployment/helm/scalarlm/values/`: `qwen3-14b`, `qwen3-32b`,
`qwen3-next-80b-fp8`, `gemma4-31b`). PR #29's docstring justification ("Qwen3.5
needs `language_model.model.layers.*`") is not exercised by any training config —
Qwen3.5 appears only as an inference model and, being multimodal, would export
`model.language_model.*` anyway.

## Testing
Ran the full adapter-format unit suite (pure dict/string logic plus `.pt`
round-trip fixtures):

```
python -m pytest tests/tokenformer/test_adapter_format.py -v
```

Result: **31 passed** (pytest 9.1.0, torch 2.12.0+cpu), including the new
`test_normalize_keeps_model_prefix_for_causal_lm_decoder` regression and the
existing `.pt` load/save fixture tests.

`vllm/tokenformer/hybrid_adapter_manager.py` compiles cleanly; its change is the
removal of the two dead methods and an unused import, with no behavioral path left
referencing them (verified by grep across `vllm/` and `tests/`).

## AI assistance
This change was developed with AI assistance (Claude). The submitting human has
reviewed every changed line and is accountable for the change end-to-end.