### PR TITLE
fix(llama): unblock Llama-class LoRA load after vLLM rebase

### DIFF
--- a/vllm/model_executor/models/llama.py
+++ b/vllm/model_executor/models/llama.py
@@ -365,12 +365,14 @@ class LlamaModel(nn.Module, EagleModelMixin):
 
         config = vllm_config.model_config.hf_config
         quant_config = vllm_config.quant_config
-        lora_config = vllm_config.lora_config
 
         self.config = config
         self.quant_config = quant_config
-        lora_vocab = (lora_config.lora_extra_vocab_size *
-                      (lora_config.max_loras or 1)) if lora_config else 0
+        # vLLM removed LoRAConfig.lora_extra_vocab_size in the version this fork
+        # rebased onto. The extra-vocab term is unused here anyway (vocab_size
+        # below has `#+ lora_vocab` commented out), so keep it 0 instead of
+        # dereferencing the removed attribute, which crashed EngineCore at load.
+        lora_vocab = 0
         self.vocab_size = config.vocab_size #+ lora_vocab
         self.org_vocab_size = config.vocab_size
         if get_pp_group().is_first_rank or (config.tie_word_embeddings

--- a/vllm/model_executor/models/llama.py
+++ b/vllm/model_executor/models/llama.py
@@ -365,6 +365,7 @@ class LlamaModel(nn.Module, EagleModelMixin):
 
         config = vllm_config.model_config.hf_config
         quant_config = vllm_config.quant_config
+        lora_config = vllm_config.lora_config
 
         self.config = config
         self.quant_config = quant_config


### PR DESCRIPTION
Two commits restore LoRA load for Llama-family models, broken by the fork's vLLM rebase:

- Restore the dropped `lora_config = vllm_config.lora_config` binding (lost in a rebase → `NameError: name 'lora_config' is not defined` at load).
- Drop the removed `LoRAConfig.lora_extra_vocab_size` reference (set `lora_vocab = 0`; the extra-vocab term is already unused — `vocab_size` keeps `#+ lora_vocab` commented out).

Net effect: `LlamaModel.__init__` no longer dereferences an attribute vLLM removed, so EngineCore stops crashing at load for Llama-class models.

Unblocks serving/fine-tuning Llama-family models in the ScalarLM finetune sweep. Qwen2-class models were unaffected.

Note: `exaone_moe.py` / `exaone_moe_mtp.py` still reference the removed attribute, but are not exercised by the finetune sweep (left for a follow-up).
