### PR TITLE
fix(adapter): detect the text-decoder layers prefix, not the vision tower

### DIFF
--- a/vllm/tokenformer/hybrid_adapter_manager.py
+++ b/vllm/tokenformer/hybrid_adapter_manager.py
@@ -118,6 +118,7 @@ class PTWorkerLoRAManager(LRUCacheWorkerLoRAManager):
         """
         try:
             model = self._adapter_manager.model
+            candidates: list[str] = []
             for name, _ in model.named_modules():
                 if name.endswith(".self_attn") or name.endswith(".mlp"):
                     # Strip the layer suffix to get the layers container
@@ -130,13 +131,29 @@ class PTWorkerLoRAManager(LRUCacheWorkerLoRAManager):
                         layers_idx = next(
                             i for i, p in enumerate(parts) if p == "layers"
                         )
-                        prefix = ".".join(parts[: layers_idx + 1]) + "."
-                        logger.debug(
-                            "Detected model layers prefix: %s", prefix
-                        )
-                        return prefix
                     except StopIteration:
                         continue
+                    prefix = ".".join(parts[: layers_idx + 1]) + "."
+                    if prefix not in candidates:
+                        candidates.append(prefix)
+            if candidates:
+                # Prefer the TEXT-DECODER prefix. On multimodal models
+                # named_modules() also yields the vision tower (e.g.
+                # "vision_tower.encoder.layers.") which can be visited
+                # first; re-prefixing decoder LoRA keys onto it collides
+                # them with the real vision keys (the Gemma4 failure mode).
+                # The decoder prefix always ends in "model.layers." — top
+                # level for Qwen3, or "language_model.model.layers." for a
+                # VL-wrapped Gemma4 — whereas the vision tower does not.
+                for prefix in candidates:
+                    if prefix.endswith("model.layers."):
+                        logger.debug("Detected model layers prefix: %s", prefix)
+                        return prefix
+                logger.debug(
+                    "Detected model layers prefix (no decoder match): %s",
+                    candidates[0],
+                )
+                return candidates[0]
         except Exception:
             pass
         logger.debug(


### PR DESCRIPTION
`_detect_model_layers_prefix` returned the first `.self_attn`/`.mlp` module's layers prefix from `named_modules()`. On multimodal Gemma4 that's the vision tower (`vision_tower.encoder.layers.`), so `_renormalize_lora_sd_for_model` re-prefixed the language-decoder LoRA keys onto it, colliding them with the real vision keys and failing `add_lora` with a "re-normalization collision" `ValueError` → `ADAPTER_NOT_LOADED`.

Fix: collect all candidate layer prefixes and prefer the text decoder (always ends in `model.layers.` — top level for Qwen3, `language_model.model.layers.` for VL-wrapped Gemma4); fall back to first-seen only if no decoder prefix exists. Single-tower models (Qwen) are unchanged.

Reproduced via `tiny-random/gemma-4-dense` in the finetune sweep.