### PR TITLE
fix(models): unblock qwen2-vl + qwen3-moe LoRA load in the finetune sweep

### DIFF
--- a/vllm/model_executor/models/qwen2_vl.py
+++ b/vllm/model_executor/models/qwen2_vl.py
@@ -1436,7 +1436,16 @@ class Qwen2VLForConditionalGeneration(
         return self.language_model.compute_logits(hidden_states)
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
-        loader = AutoWeightsLoader(self)
+        skip_prefixes = []
+        if self.config.tie_word_embeddings:
+            # Tied embeddings: lm_head shares embed_tokens' weight, so a tied
+            # checkpoint carries no separate lm_head weight. Skip it from the
+            # init-completeness check or AutoWeightsLoader raises
+            # "language_model.lm_head.weight not initialized". Mirrors qwen2.py,
+            # adjusted for the VL module prefix (hf_to_vllm_mapper rewrites
+            # `lm_head.` -> `language_model.lm_head.`, the model-tree name).
+            skip_prefixes.append("language_model.lm_head.")
+        loader = AutoWeightsLoader(self, skip_prefixes=skip_prefixes or None)
         return loader.load_weights(weights, mapper=self.hf_to_vllm_mapper)
 
     def get_mm_mapping(self) -> MultiModelKeys:

--- a/vllm/model_executor/models/qwen3_moe.py
+++ b/vllm/model_executor/models/qwen3_moe.py
@@ -684,7 +684,17 @@ class Qwen3MoeForCausalLM(
             "q_proj",
             "k_proj",
             "v_proj",
-        ]
+        ],
+        # Dense `Qwen3MoeMLP` blocks (the non-sparse layers, plus every sparse
+        # layer's `shared_expert`) fuse gate+up into one MergedColumnParallelLinear.
+        # It must be in the packed mapping or the LoRA manager can't wrap it
+        # (`MergedColumnParallelLinearWithLoRA.can_replace_layer` needs the 2-part
+        # mapping) and asserts at engine init. Declared unconditionally: a fully
+        # sparse model simply has no `gate_up_proj` module for it to match.
+        "gate_up_proj": [
+            "gate_proj",
+            "up_proj",
+        ],
     }
 
     embedding_modules = {
@@ -700,9 +710,10 @@ class Qwen3MoeForCausalLM(
         quant_config = vllm_config.quant_config
         self.config = config
         self.quant_config = quant_config
-        # Only perform the following mapping when Qwen3MoeMLP exists
-        if getattr(config, "mlp_only_layers", []):
-            self.packed_modules_mapping["gate_up_proj"] = ["gate_proj", "up_proj"]
+        # `gate_up_proj` is now declared on the class-level packed_modules_mapping
+        # (covers dense layers whether they come from `mlp_only_layers` or from the
+        # `decoder_sparse_step` cadence), so no per-instance mutation here — that
+        # also avoids mutating the shared class attribute.
         self.model = Qwen3MoeModel(
             vllm_config=vllm_config, prefix=maybe_prefix(prefix, "model")
         )


### PR DESCRIPTION
Two engine-init crashes the finetune sweep surfaced on tiny-random fixtures:

**qwen2-vl** — `Qwen2VLForConditionalGeneration.load_weights` now skips the tied `language_model.lm_head.` from the init-completeness check when `tie_word_embeddings`. The `hf_to_vllm_mapper` rewrites `lm_head.` → `language_model.lm_head.`, so the skip prefix is the model-tree name (not `lm_head.` as in qwen2.py). Fixes `ValueError: ...language_model.lm_head.weight not initialized`.

**qwen3-moe** — declare `gate_up_proj` in the class-level `packed_modules_mapping` and drop the `if mlp_only_layers:` conditional. A layer is dense (`Qwen3MoeMLP` with a fused `gate_up_proj`) whenever `(layer_idx+1) % decoder_sparse_step != 0`, even with empty `mlp_only_layers`, so the conditional left those dense modules out of the mapping → `MergedColumnParallelLinearWithLoRA.can_replace_layer` failed → the module wasn't wrapped → LoRA register assert `gate_up_proj must be a BaseLayerWithLoRA`. Declaring it unconditionally is safe (a fully sparse model has no `gate_up_proj` module to match) and removes a shared-class-state mutation.