### PR TITLE
fix(tokenformer): skip stacked MoE expert tensors in infer_lora_rank

### DIFF
--- a/tests/tokenformer/test_lora_from_pt.py
+++ b/tests/tokenformer/test_lora_from_pt.py
@@ -83,6 +83,37 @@ def test_infer_rank_ignores_non_lora_keys():
     assert infer_lora_rank(sd) == 8
 
 
+def test_infer_rank_ignores_moe_expert_stacked_tensors():
+    from vllm.tokenformer.lora_from_pt import infer_lora_rank
+
+    # A Qwen3MoE adapter (real shapes from yujiepan/qwen3-moe-tiny-random): the
+    # attention lora_A tensors carry the true rank (8) in shape[0], while the
+    # fused-expert lora_A tensors stack rank×num_experts(×gate/up) into shape[0]
+    # (128, 64) under `.experts` keys. The old single-rank check raised
+    # "Inconsistent LoRA ranks across lora_A tensors: [8, 64, 128]". Rank
+    # inference must read the attention tensors and ignore the expert ones.
+    sd = {
+        "model.layers.0.self_attn.q_proj.lora_A.weight": _fake_tensor((8, 64)),
+        "model.layers.0.self_attn.k_proj.lora_A.weight": _fake_tensor((8, 64)),
+        "model.layers.1.mlp.experts.base_layer.lora_A.weight": _fake_tensor((128, 64)),
+        "model.layers.1.mlp.experts.lora_A.weight": _fake_tensor((64, 128)),
+    }
+    assert infer_lora_rank(sd) == 8
+
+
+def test_infer_rank_only_expert_tensors_raises():
+    from vllm.tokenformer.lora_from_pt import infer_lora_rank
+
+    # An adapter with only `.experts` lora_A (no standard tensor to read the
+    # rank from) can't have its rank inferred — the stacked leading dim is not
+    # the rank.
+    sd = {
+        "model.layers.1.mlp.experts.lora_A.weight": _fake_tensor((64, 128)),
+    }
+    with pytest.raises(ValueError, match="No lora_A tensors"):
+        infer_lora_rank(sd)
+
+
 # --- build_peft_helper_from_pt -----------------------------------------
 
 

--- a/vllm/tokenformer/lora_from_pt.py
+++ b/vllm/tokenformer/lora_from_pt.py
@@ -42,6 +42,17 @@ def infer_lora_rank(lora_sd: dict[str, Any]) -> int:
     ranks_by_key: dict[str, int] = {}
     for key, tensor in lora_sd.items():
         if ".lora_A." in key:
+            # MoE expert LoRA tensors (PEFT fused format: `experts.base_layer`
+            # = gate_up_proj, `experts` = down_proj) stack the adapter rank with
+            # num_experts (and the gate/up split) into the leading dim, so
+            # `shape[0]` is rank × num_experts × parts, NOT the adapter rank. A
+            # Qwen3MoE adapter therefore shows e.g. {8 (attn), 64, 128 (experts)}
+            # and the old single-rank check raised "Inconsistent LoRA ranks".
+            # Infer the rank from the standard (non-expert) lora_A tensors, whose
+            # leading dim is the true rank; vLLM's FusedMoEWithLoRA reconstructs
+            # the per-expert rank from the stacked tensors downstream.
+            if ".experts" in key:
+                continue
             try:
                 rank = int(tensor.shape[0])
             except (AttributeError, TypeError, IndexError) as exc:
@@ -52,7 +63,9 @@ def infer_lora_rank(lora_sd: dict[str, Any]) -> int:
 
     if not ranks_by_key:
         raise ValueError(
-            "No lora_A tensors found — cannot infer rank from state dict."
+            "No lora_A tensors found — cannot infer rank from state dict. "
+            "(Expert `.experts` lora_A tensors are excluded from rank inference "
+            "because they stack rank×num_experts in the leading dim.)"
         )
 
     unique_ranks = set(ranks_by_key.values())


### PR DESCRIPTION
MoE expert `lora_A` tensors stack `rank × num_experts` (× gate/up) into `shape[0]`, so `infer_lora_rank` read inconsistent ranks (e.g. `[8, 64, 128]`) and raised "Inconsistent LoRA ranks across lora_A tensors".

Fix: skip `.experts` keys and read the rank from the standard (attention) `lora_A` tensors, whose leading dim is the true rank. vLLM's `FusedMoEWithLoRA` reconstructs the per-expert rank from the stacked tensors downstream.

GPU-validated on the DGX Spark: qwen3-moe attention LoRA now loads and serves cleanly (was `ADAPTER_NOT_LOADED`).

Includes two regression tests (`test_infer_rank_ignores_moe_expert_stacked_tensors`, `test_infer_rank_only_expert_tensors_raises`).

Out of scope: expert-fused LoRA serving is a separate, deferred gap.