### PR TITLE
DiffusionGemma serving path (canvas decode)

### DIFF
--- a/vllm/model_executor/models/diffusion_gemma.py
+++ b/vllm/model_executor/models/diffusion_gemma.py
@@ -31,6 +31,7 @@ from vllm.config.compilation import CUDAGraphMode
 from vllm.distributed.parallel_state import get_tp_group
 from vllm.logger import init_logger
 from vllm.model_executor.layers.layernorm import RMSNorm
+from vllm.model_executor.layers.linear import ReplicatedLinear
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
 from vllm.model_executor.layers.vocab_parallel_embedding import (
     ParallelLMHead,
@@ -81,9 +82,21 @@ class DiffusionGemmaSelfConditioning(nn.Module):
         super().__init__()
         self.pre_norm = RMSNorm(hidden_size, eps=eps)
         self.post_norm = RMSNorm(hidden_size, eps=eps, has_weight=False)
-        self.gate_proj = nn.Linear(hidden_size, self_conditioning_size, bias=False)
-        self.up_proj = nn.Linear(hidden_size, self_conditioning_size, bias=False)
-        self.down_proj = nn.Linear(self_conditioning_size, hidden_size, bias=False)
+        # ReplicatedLinear (not nn.Linear) so the LoRA manager can wrap these as
+        # ReplicatedLinearWithLoRA — the trainer adapts the self-conditioning MLP
+        # (self_conditioning.{gate,up,down}_proj) and that adapter must apply at
+        # serve to match training's self-conditioning feedback. Weights still load
+        # via the manual .data.copy_ in load_weights (.weight shape is unchanged);
+        # LoRA scope is opened by adding self_conditioning to get_mm_mapping.
+        self.gate_proj = ReplicatedLinear(
+            hidden_size, self_conditioning_size, bias=False
+        )
+        self.up_proj = ReplicatedLinear(
+            hidden_size, self_conditioning_size, bias=False
+        )
+        self.down_proj = ReplicatedLinear(
+            self_conditioning_size, hidden_size, bias=False
+        )
 
     def forward(
         self,
@@ -91,9 +104,9 @@ class DiffusionGemmaSelfConditioning(nn.Module):
         soft_embeds: torch.Tensor,
     ) -> torch.Tensor:
         x = self.pre_norm(soft_embeds)
-        sc_signal = self.down_proj(
-            F.gelu(self.gate_proj(x), approximate="tanh") * self.up_proj(x)
-        )
+        gate, _ = self.gate_proj(x)
+        up, _ = self.up_proj(x)
+        sc_signal, _ = self.down_proj(F.gelu(gate, approximate="tanh") * up)
         return self.post_norm(inputs_embeds + sc_signal)
 
 
@@ -316,7 +329,10 @@ class DiffusionGemmaForConditionalGeneration(
     def get_mm_mapping(self) -> MultiModelKeys:
         """Get the module prefix mapping for multimodal models."""
         return MultiModelKeys.from_string_field(
-            language_model="model",
+            # self_conditioning is a sibling of `model` (top-level), not under it,
+            # so it must be listed explicitly or the LoRA manager treats it as
+            # out-of-scope and ignores its adapter keys ("no matching PunicaWrapper").
+            language_model=["model", "self_conditioning"],
             connector=["embed_vision"],
             tower_model=["vision_tower"],
         )

--- a/vllm/model_executor/models/diffusion_gemma.py
+++ b/vllm/model_executor/models/diffusion_gemma.py
@@ -656,7 +656,11 @@ def _compiled_sample_step(
     if tp_size > 1:
         soft_embeds = torch.ops.vllm.all_reduce(soft_embeds, group_name=tp_group_name)
     soft_embeds = soft_embeds * normalizer
-    sc_embeds[decode_slots] = soft_embeds * sc_keep
+    # sc_embeds is a persistent fp32 buffer (see DiffusionGemmaRequestStates)
+    # while soft_embeds is bf16 (probs @ embed_weight); index_put_ requires the
+    # source dtype to match the destination, so cast to the buffer dtype. The
+    # consumer (_apply_self_conditioning) symmetrically casts back on read.
+    sc_embeds[decode_slots] = (soft_embeds * sc_keep).to(sc_embeds.dtype)
 
     # Overwrite canvas with argmax for newly converged denoise requests
     newly_converged = (converged & is_denoise).unsqueeze(1)

--- a/vllm/model_executor/models/diffusion_gemma.py
+++ b/vllm/model_executor/models/diffusion_gemma.py
@@ -59,6 +59,7 @@ from vllm.v1.worker.gpu.sample.penalties import use_penalty
 from vllm.v1.worker.gpu.states import RequestState
 
 from .interfaces import (
+    SupportsLoRA,
     SupportsMultiModal,
     SupportsPP,
     SupportsQuant,
@@ -143,6 +144,7 @@ class DiffusionGemmaForConditionalGeneration(
     SupportsMultiModal,
     SupportsQuant,
     SupportsPP,
+    SupportsLoRA,
 ):
     """DiffusionGemma for vLLM.
 
@@ -173,6 +175,16 @@ class DiffusionGemmaForConditionalGeneration(
         "qkv_proj": ["q_proj", "k_proj", "v_proj"],
         "gate_up_proj": ["gate_proj", "up_proj"],
     }
+
+    # SupportsLoRA metadata. LoRA is confined to the language backbone (`self.model`,
+    # the shared Gemma4 encoder/decoder tower) by get_mm_mapping(language_model=
+    # "model"); the vision tower and connector are excluded. The ScalarLM trainer
+    # adapts the DECODER only (ADR 0007) and exports `.pt` keys under
+    # `model.decoder.layers.*`; hf_to_vllm_mapper's `model.decoder.` -> `model.`
+    # prefix rule (above) maps them onto this single backbone. No LoRA on the
+    # embeddings (canvas denoising doesn't adapt them).
+    embedding_modules: dict[str, str] = {}
+    embedding_padding_modules: list[str] = []
 
     @staticmethod
     def get_model_state_cls():

--- a/vllm/model_executor/models/diffusion_gemma.py
+++ b/vllm/model_executor/models/diffusion_gemma.py
@@ -284,7 +284,13 @@ class DiffusionGemmaForConditionalGeneration(
             getattr(config, "self_conditioning_size", None)
             or text_config.intermediate_size
         )
-        self.self_conditioning = DiffusionGemmaSelfConditioning(
+        # Attach the self-conditioning MLP ONTO the backbone so its modules
+        # live at `model.self_conditioning.*`. vLLM's multimodal-LoRA path
+        # allows exactly one `language_model` tower and routes modules to it by
+        # prefix; homing self_conditioning under the `model.` prefix brings its
+        # adapter into scope without a second (illegal) tower and keeps lm_head
+        # out of LoRA scope.
+        self.model.self_conditioning = DiffusionGemmaSelfConditioning(
             hidden_size=text_config.hidden_size,
             self_conditioning_size=sc_size,
             eps=getattr(text_config, "rms_norm_eps", 1e-6),
@@ -303,7 +309,7 @@ class DiffusionGemmaForConditionalGeneration(
         soft_embeds = torch.matmul(
             probs.to(embed_weight.dtype), embed_weight
         ) * self.model.normalizer.to(inputs_embeds.dtype)
-        return self.self_conditioning(inputs_embeds, soft_embeds)
+        return self.model.self_conditioning(inputs_embeds, soft_embeds)
 
     # ------------------------------------------------------------------ #
     # Multimodal: reuse Gemma4's image parsing, processing & embedding
@@ -329,10 +335,11 @@ class DiffusionGemmaForConditionalGeneration(
     def get_mm_mapping(self) -> MultiModelKeys:
         """Get the module prefix mapping for multimodal models."""
         return MultiModelKeys.from_string_field(
-            # self_conditioning is a sibling of `model` (top-level), not under it,
-            # so it must be listed explicitly or the LoRA manager treats it as
-            # out-of-scope and ignores its adapter keys ("no matching PunicaWrapper").
-            language_model=["model", "self_conditioning"],
+            # self_conditioning is homed under the backbone (`model.`), so a
+            # single language_model tower covers both the decoder and the
+            # self-conditioning MLP. vLLM asserts exactly one language_model
+            # entry, so it MUST stay a single prefix.
+            language_model="model",
             connector=["embed_vision"],
             tower_model=["vision_tower"],
         )
@@ -385,7 +392,7 @@ class DiffusionGemmaForConditionalGeneration(
         sc_params = dict(
             (n, p)
             for n, p in self.named_parameters()
-            if n.startswith("self_conditioning.")
+            if n.startswith("model.self_conditioning.")
         )
 
         # Collect vision tower + embedder parameters AND buffers for manual
@@ -408,10 +415,11 @@ class DiffusionGemmaForConditionalGeneration(
             seen_weights: set[str] = set()
             for name, weight in weights:
                 # Self-conditioning lives under model.decoder.self_conditioning.*
-                # in the checkpoint but at self_conditioning.* in our model.
+                # in the checkpoint but at model.self_conditioning.* in our model
+                # (homed under the backbone for single-tower LoRA scope).
                 if "self_conditioning" in name:
                     sc_name = name.split("self_conditioning.", 1)[1]
-                    sc_name = "self_conditioning." + sc_name
+                    sc_name = "model.self_conditioning." + sc_name
                     if sc_name in sc_params:
                         sc_params[sc_name].data.copy_(weight)
                     continue
@@ -953,7 +961,7 @@ class DiffusionGemmaModelState(ModelState):
             end = int(query_start_loc_np[idx + 1])
             canvas = slice(start, end)
             soft = sc_embeds[slot, : end - start]
-            inputs_embeds[canvas] = self.model.self_conditioning(
+            inputs_embeds[canvas] = self.model.model.self_conditioning(
                 inputs_embeds[canvas], soft.to(inputs_embeds.dtype)
             )
 

--- a/vllm/tokenformer/hybrid_adapter_manager.py
+++ b/vllm/tokenformer/hybrid_adapter_manager.py
@@ -263,14 +263,15 @@ class PTWorkerLoRAManager(LRUCacheWorkerLoRAManager):
 
             # DiffusionGemma self-conditioning MLP: the trainer saves it under
             # `model.decoder.self_conditioning.*` (pass-1 strips `model.` ->
-            # `decoder.self_conditioning.*`), but vLLM exposes it at TOP LEVEL as
-            # `self_conditioning.*` (a sibling of `model`, not on the layers
-            # backbone). Anchor on the `self_conditioning.` segment and drop
-            # everything before it. Must run before the layers logic since these
-            # keys never start with a `layers.` prefix. No-op for other models.
+            # `decoder.self_conditioning.*`), but vLLM homes it under the
+            # backbone at `model.self_conditioning.*` (so a single `model.`
+            # language_model tower covers it for LoRA). Anchor on the
+            # `self_conditioning.` segment and re-prefix with `model.`. Must run
+            # before the layers logic since these keys never start with a
+            # `layers.` prefix. No-op for other models.
             SC_MARKER = "self_conditioning."
             if SC_MARKER in k:
-                nk = k[k.index(SC_MARKER):]
+                nk = "model." + k[k.index(SC_MARKER):]
                 if nk in out:
                     raise ValueError(
                         f"LoRA key re-normalization collision: {k!r} and an "

--- a/vllm/tokenformer/hybrid_adapter_manager.py
+++ b/vllm/tokenformer/hybrid_adapter_manager.py
@@ -260,6 +260,25 @@ class PTWorkerLoRAManager(LRUCacheWorkerLoRAManager):
                 "decoder.layers.",
                 "model.layers.",
             )
+
+            # DiffusionGemma self-conditioning MLP: the trainer saves it under
+            # `model.decoder.self_conditioning.*` (pass-1 strips `model.` ->
+            # `decoder.self_conditioning.*`), but vLLM exposes it at TOP LEVEL as
+            # `self_conditioning.*` (a sibling of `model`, not on the layers
+            # backbone). Anchor on the `self_conditioning.` segment and drop
+            # everything before it. Must run before the layers logic since these
+            # keys never start with a `layers.` prefix. No-op for other models.
+            SC_MARKER = "self_conditioning."
+            if SC_MARKER in k:
+                nk = k[k.index(SC_MARKER):]
+                if nk in out:
+                    raise ValueError(
+                        f"LoRA key re-normalization collision: {k!r} and an "
+                        f"earlier key both map to {nk!r}."
+                    )
+                out[nk] = v
+                continue
+
             bare = k
             for kp in KNOWN_PREFIXES:
                 if k.startswith(kp):

--- a/vllm/tokenformer/hybrid_adapter_manager.py
+++ b/vllm/tokenformer/hybrid_adapter_manager.py
@@ -240,17 +240,24 @@ class PTWorkerLoRAManager(LRUCacheWorkerLoRAManager):
             # with a known vLLM prefix that isn't the target, strip it
             # back to bare "layers.*" then re-prefix.
             #
-            # `model.decoder.layers.` is the DiffusionGemma trainer prefix:
-            # the trainer adapts the decoder (ADR 0007) and saves keys under
-            # `model.decoder.layers.*`, but the vLLM port collapses the tied
-            # encoder/decoder into a single `model.layers.*` backbone (its
-            # hf_to_vllm_mapper maps `model.decoder.` -> `model.`). Stripping
-            # `decoder.` here maps the decoder LoRA onto that shared backbone;
-            # without it the keys never match and the adapter is skipped as
-            # "zero base-module overlap". No-op for non-diffusion models.
+            # DiffusionGemma trainer prefix: the trainer adapts the decoder
+            # (ADR 0007) and saves keys under `model.decoder.layers.*`, but the
+            # vLLM port collapses the tied encoder/decoder into a single
+            # `model.layers.*` backbone (its hf_to_vllm_mapper maps
+            # `model.decoder.` -> `model.`). Stripping `decoder.` here maps the
+            # decoder LoRA onto that shared backbone; without it the keys never
+            # match and the adapter is skipped as "zero base-module overlap".
+            #
+            # NOTE the bare `decoder.layers.` form: pass-1 `normalize_lora_key`
+            # sees `model.decoder.layers.*`, fails its `model.layers.` /
+            # `model.language_model.` special-cases, and falls into the generic
+            # "strip leading `model.`" branch -> the key reaches us as
+            # `decoder.layers.*` (no `model.`). So we must match that form, not
+            # only `model.decoder.layers.`. No-op for non-diffusion models.
             KNOWN_PREFIXES = (
                 "language_model.model.layers.",
                 "model.decoder.layers.",
+                "decoder.layers.",
                 "model.layers.",
             )
             bare = k

--- a/vllm/tokenformer/hybrid_adapter_manager.py
+++ b/vllm/tokenformer/hybrid_adapter_manager.py
@@ -239,8 +239,18 @@ class PTWorkerLoRAManager(LRUCacheWorkerLoRAManager):
             # Undo any previous prefix normalization: if the key starts
             # with a known vLLM prefix that isn't the target, strip it
             # back to bare "layers.*" then re-prefix.
+            #
+            # `model.decoder.layers.` is the DiffusionGemma trainer prefix:
+            # the trainer adapts the decoder (ADR 0007) and saves keys under
+            # `model.decoder.layers.*`, but the vLLM port collapses the tied
+            # encoder/decoder into a single `model.layers.*` backbone (its
+            # hf_to_vllm_mapper maps `model.decoder.` -> `model.`). Stripping
+            # `decoder.` here maps the decoder LoRA onto that shared backbone;
+            # without it the keys never match and the adapter is skipped as
+            # "zero base-module overlap". No-op for non-diffusion models.
             KNOWN_PREFIXES = (
                 "language_model.model.layers.",
+                "model.decoder.layers.",
                 "model.layers.",
             )
             bare = k


### PR DESCRIPTION
Serve-side counterpart to the scalarlm diffusion training PR. Stacks on the v0.25 migration branch.